### PR TITLE
Ignore certain directories

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/fatih/color"
 )
@@ -40,9 +40,15 @@ func (t *NodeTree) Sync() error {
 		}
 		if f.IsDir() {
 
-			name := f.Name()
-
-			if(strings.HasPrefix(name, "x_") || strings.HasPrefix(name, "x-")) {
+			// Ignore directories
+			//	- that start with x_ or x-
+			//	- that start with .
+			//	- node_modules
+			matched, err := regexp.MatchString("^x{1}[-_]{1}|node_modules|^\\.", f.Name())
+			if err != nil {
+				return err
+			}
+			if(matched) {
 				red := color.New(color.FgRed).SprintFunc()
 				log.Printf("Ignoring node: %s", red(path));
 				return filepath.SkipDir

--- a/nodes.go
+++ b/nodes.go
@@ -44,7 +44,7 @@ func (t *NodeTree) Sync() error {
 			//	- that start with x_ or x-
 			//	- that start with .
 			//	- node_modules
-			matched, err := regexp.MatchString("^x{1}[-_]{1}|node_modules|^\\.", f.Name())
+			matched, err := regexp.MatchString("^x{1}[-_]{1}|^\\.|node_modules", f.Name())
 			if err != nil {
 				return err
 			}

--- a/nodes.go
+++ b/nodes.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 )
@@ -38,10 +39,19 @@ func (t *NodeTree) Sync() error {
 			return err
 		}
 		if f.IsDir() {
+
+			name := f.Name()
+
+			if(strings.HasPrefix(name, "x_") || strings.HasPrefix(name, "x-")) {
+				red := color.New(color.FgRed).SprintFunc()
+				log.Printf("Ignoring node: %s", red(path));
+				return filepath.SkipDir
+			}
+
 			n, nErr := NewNodeFromPath(path, root)
 			if nErr != nil {
 				red := color.New(color.FgRed).SprintFunc()
-				log.Printf("ghosting node: %s", red(nErr))
+				log.Printf("Ghosting node: %s", red(nErr))
 			}
 			nodes = append(nodes, n)
 		}


### PR DESCRIPTION
Introduces ignore rules for directories that start with `.`, `x-`, `x_`; and `node_modules`.