### PR TITLE
Components inside documents

### DIFF
--- a/node_doc_test.go
+++ b/node_doc_test.go
@@ -33,3 +33,213 @@ func TestDocTitlesWithDecomposedFilenames(t *testing.T) {
 		t.Errorf("failed to decode file name, got %v", docs[0].Title())
 	}
 }
+
+// func TestBlockReactComponentInHTML(t *testing.T) {
+// 	tmp, _ := ioutil.TempDir("", "tree")
+// 	defer os.RemoveAll(tmp)
+//
+// 	get := func(url string) (bool, *Node, error) {
+// 		return false, &Node{}, nil
+// 	}
+//
+// 	node0 := filepath.Join(tmp, "foo")
+// 	os.Mkdir(node0, 0777)
+//
+// 	doc0 := filepath.Join(node0, "readme.html")
+// 	raw0 := `
+// <script type="text/jsx">
+// <CodeBlock title="Example">
+//   echo "GREETINGS PROFESSOR FALKEN."
+// </CodeBlock>
+// </script>
+// `
+// 	expected0 := `
+// <div id="dsk-component-mount-point-123"></div>
+// <script>
+// React.createElement(CodeBlock, {
+//   title: "Example"
+// }, "echo 'GREETINGS PROFESSOR FALKEN.'");
+// </script>
+// `
+// 	ioutil.WriteFile(doc0, []byte(raw0), 0666)
+//
+// 	node := &Node{root: tmp, path: filepath.Join(tmp, "foo")}
+// 	docs, _ := node.Docs()
+//
+// 	html0, _ := docs[0].HTML("/tree", "foo/bar", get)
+//
+// 	if string(html0) != expected0 {
+// 		t.Errorf("Component markup does not look like expected, got: %s", html0)
+// 	}
+// }
+
+func TestBlockWebComponentInHTML(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "tree")
+	defer os.RemoveAll(tmp)
+
+	get := func(url string) (bool, *Node, error) {
+		return false, &Node{}, nil
+	}
+
+	node0 := filepath.Join(tmp, "foo")
+	os.Mkdir(node0, 0777)
+
+	doc0 := filepath.Join(node0, "readme.html")
+	raw0 := `
+<dsk-code-block>
+  echo "GREETINGS PROFESSOR FALKEN."	
+</dsk-code-block>
+`
+	expected0 := `
+<dsk-code-block>
+  echo "GREETINGS PROFESSOR FALKEN."	
+</dsk-code-block>
+`
+	ioutil.WriteFile(doc0, []byte(raw0), 0666)
+
+	node := &Node{root: tmp, path: filepath.Join(tmp, "foo")}
+	docs, _ := node.Docs()
+
+	html0, _ := docs[0].HTML("/tree", "foo/bar", get)
+
+	if string(html0) != expected0 {
+		t.Errorf("Component markup does not look like expected, got: %s", html0)
+	}
+}
+
+// func TestBlockWebComponentInMarkdown(t *testing.T) {
+// 	tmp, _ := ioutil.TempDir("", "tree")
+// 	defer os.RemoveAll(tmp)
+//
+// 	get := func(url string) (bool, *Node, error) {
+// 		return false, &Node{}, nil
+// 	}
+//
+// 	node0 := filepath.Join(tmp, "foo")
+// 	os.Mkdir(node0, 0777)
+//
+// 	doc0 := filepath.Join(node0, "readme.md")
+// 	raw0 := `
+// <dsk-code-block>
+//   echo "GREETINGS PROFESSOR FALKEN."
+// </dsk-code-block>
+// `
+// 	expected0 := `
+// <dsk-code-block>
+//   echo "GREETINGS PROFESSOR FALKEN."
+// </dsk-code-block>
+// `
+// 	ioutil.WriteFile(doc0, []byte(raw0), 0666)
+//
+// 	node := &Node{root: tmp, path: filepath.Join(tmp, "foo")}
+// 	docs, _ := node.Docs()
+//
+// 	html0, _ := docs[0].HTML("/tree", "foo/bar", get)
+//
+// 	if string(html0) != expected0 {
+// 		t.Errorf("Component markup does not look like expected, got: %s", html0)
+// 	}
+// }
+
+func TestImpliedScriptTagsBlockReactComponentInMarkdown(t *testing.T) {
+	raw0 := `
+<CodeBlock title="Example">
+  echo "GREETINGS PROFESSOR FALKEN."
+</CodeBlock>
+`
+	expected0 := `
+<script><CodeBlock title="Example">
+  echo "GREETINGS PROFESSOR FALKEN."
+</CodeBlock></script>
+`
+	result0, _ := implyScriptTags([]byte(raw0))
+	if string(result0) != expected0 {
+		t.Errorf("Failed to imply script tags, got: %s", result0)
+	}
+}
+
+// func TestBlockReactComponentInMarkdown(t *testing.T) {
+// 	tmp, _ := ioutil.TempDir("", "tree")
+// 	defer os.RemoveAll(tmp)
+//
+// 	get := func(url string) (bool, *Node, error) {
+// 		return false, &Node{}, nil
+// 	}
+//
+// 	node0 := filepath.Join(tmp, "foo")
+// 	os.Mkdir(node0, 0777)
+//
+// 	doc0 := filepath.Join(node0, "readme.md")
+// 	raw0 := `
+// <CodeBlock title="Example">
+//   echo "GREETINGS PROFESSOR FALKEN."
+// </CodeBlock>
+// `
+// 	expected0 := `
+// <div id="dsk-component-mount-point-123"></div>
+// <script>
+// React.createElement(CodeBlock, {
+//   title: "Example"
+// }, "echo 'GREETINGS PROFESSOR FALKEN.'");
+// </script>
+// `
+// 	ioutil.WriteFile(doc0, []byte(raw0), 0666)
+//
+// 	node := &Node{root: tmp, path: filepath.Join(tmp, "foo")}
+// 	docs, _ := node.Docs()
+//
+// 	html0, _ := docs[0].HTML("/tree", "foo/bar", get)
+//
+// 	if string(html0) != expected0 {
+// 		t.Errorf("Component markup does not look like expected, got: %s", html0)
+// 	}
+// }
+
+func TestImpliedScriptTagsInlineReactComponentInMarkdown(t *testing.T) {
+	raw0 := `
+Yellow and <ColorSwatch>green</ColorSwatch> are the colors of spring.
+`
+	expected0 := `
+Yellow and <script><ColorSwatch>green</ColorSwatch></script> are the colors of spring.
+`
+	result0, _ := implyScriptTags([]byte(raw0))
+	if string(result0) != expected0 {
+		t.Errorf("Failed to imply script tags, got: %s", result0)
+	}
+}
+
+// func TestInlineReactComponentInMarkdown(t *testing.T) {
+// 	tmp, _ := ioutil.TempDir("", "tree")
+// 	defer os.RemoveAll(tmp)
+//
+// 	get := func(url string) (bool, *Node, error) {
+// 		return false, &Node{}, nil
+// 	}
+//
+// 	node0 := filepath.Join(tmp, "foo")
+// 	os.Mkdir(node0, 0777)
+//
+// 	doc0 := filepath.Join(node0, "readme.md")
+// 	raw0 := `
+// Yellow and <ColorSwatch>green</ColorSwatch> are the colors of spring.
+// `
+// 	expected0 := `
+// <p>
+// Yellow and <div class="dsk-component-mount-point-123"></div> are the colors of spring.
+// </p>
+// <script>
+// React.createElement(ColorSwatch, null, "green");
+// </script>
+// `
+//
+// 	ioutil.WriteFile(doc0, []byte(raw0), 0666)
+//
+// 	node := &Node{root: tmp, path: filepath.Join(tmp, "foo")}
+// 	docs, _ := node.Docs()
+//
+// 	html0, _ := docs[0].HTML("/tree", "foo/bar", get)
+//
+// 	if string(html0) != expected0 {
+// 		t.Errorf("Component markup does not look like expected, got: %s", html0)
+// 	}
+// }


### PR DESCRIPTION
[MDX](https://mdxjs.com/) inspired us. We also see great value in being able to use components inside DSK documents. 

We see two strong cases for components in documents: 

1. _Documentation components_, i.e. a `ColorSwatch`-component that enhances the documentation. These kind of components are provided through the built-in frontend.

```
<ColorSpecimen src="./colors.some">
```

2. _Design system components_, i.e. a component that is talked about inside the design system and used wherever the design system is applied. These kind of components are provided through externally built _bundles_ that are stored next to/inside the DDT.

```
<DiskoTextField></DiskoTextField>
```

Both can also be combined, (`Playground` is a documentation component):

```
<Playground>
   <DiskoTextField></DiskoTextField>
</Playground>
```

We go beyond MDX: We imagine to at least support WebComponents and React-Components expressed in JSX. The implementation should allow to later add support for Vue-Components.  
Components will be supported in all document formats that can currently be used. HTML and Markdown.

TODOs:

- [x] protect JSX in documents from being parsed
- [ ] support WebComponents in documents
- [ ] transpile JSX in the backend
- [ ] have some basic documentation components, to play with
- [ ] document which documentation components are available when authoring documents
- [ ] decide if the DDT can/should be used for anything else than documents (bundles, config) or if these need to stay outside of the DDT
- [ ] API endpoint to list loadable bundles and a way to load them
- [ ] bridge into bundles (registry?), so there is a unified way to load a component from a bundle by its name