### PR TITLE
Implements implicit logical AND in filter search query

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -96,9 +96,7 @@ function App(props) {
   useEffect(loadTree, []);
 
   // Load the current node being displayed. Reload it whenever the route changes.
-  useEffect(() => {
-    loadNode();
-  }, [props.route]);
+  useEffect(loadNode, [props.route]);
 
   let content;
   if (error) {

--- a/search_test.go
+++ b/search_test.go
@@ -458,3 +458,44 @@ func expectNoFilterSearchResult(t *testing.T, nodes []*Node, url string) {
 		}
 	}
 }
+
+func TestFilterSearchMultipleTagsWithLogicalAndInQuery(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "tree")
+
+	n0 := NewNode(filepath.Join(tmp, "Colors"), tmp)
+	n0.Create()
+	n0.CreateMeta("meta.yaml", &NodeMeta{
+		Tags: []string{"foo", "bar", "qux"},
+	})
+	n0.Load()
+
+	n1 := NewNode(filepath.Join(tmp, "Navigation"), tmp)
+	n1.Create()
+	n1.CreateMeta("meta.yaml", &NodeMeta{
+		Tags: []string{"foo"},
+	})
+	n1.Load()
+
+	n2 := NewNode(filepath.Join(tmp, "Type"), tmp)
+	n2.Create()
+	n2.CreateMeta("meta.yaml", &NodeMeta{
+		Tags: []string{"bar"},
+	})
+	n2.Load()
+
+	s := setupSearchTest(t, tmp, "en", []*Node{n0, n1, n2})
+	defer teardownSearchTest(tmp, s)
+
+	rs, _, _, _, _ := s.FilterSearch("foo", false)
+	expectFilterSearchResult(t, rs, "Colors")
+	expectFilterSearchResult(t, rs, "Navigation")
+
+	rs, _, _, _, _ = s.FilterSearch("bar", false)
+	expectFilterSearchResult(t, rs, "Colors")
+	expectFilterSearchResult(t, rs, "Type")
+
+	rs, _, _, _, _ = s.FilterSearch("foo bar", false)
+	expectFilterSearchResult(t, rs, "Colors")
+	expectNoFilterSearchResult(t, rs, "Navigation")
+	expectNoFilterSearchResult(t, rs, "Type")
+}

--- a/search_test.go
+++ b/search_test.go
@@ -498,4 +498,15 @@ func TestFilterSearchMultipleTagsWithLogicalAndInQuery(t *testing.T) {
 	expectFilterSearchResult(t, rs, "Colors")
 	expectNoFilterSearchResult(t, rs, "Navigation")
 	expectNoFilterSearchResult(t, rs, "Type")
+
+	rs, _, _, _, _ = s.FilterSearch("foo col", false)
+	expectFilterSearchResult(t, rs, "Colors")
+	expectNoFilterSearchResult(t, rs, "Navigation")
+	expectNoFilterSearchResult(t, rs, "Type")
+
+	rs, _, _, _, _ = s.FilterSearch("foo shadows", false)
+	expectNoFilterSearchResult(t, rs, "Colors")
+	expectNoFilterSearchResult(t, rs, "Navigation")
+	expectNoFilterSearchResult(t, rs, "Type")
+}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -509,4 +509,3 @@ func TestFilterSearchMultipleTagsWithLogicalAndInQuery(t *testing.T) {
 	expectNoFilterSearchResult(t, rs, "Navigation")
 	expectNoFilterSearchResult(t, rs, "Type")
 }
-}


### PR DESCRIPTION
Regression: TestFilterSearchGermanWordPartials now fails, but this is the same problem we are trying to solve for the full search on search-refinement.